### PR TITLE
Add onboarding placeholders and role dashboards

### DIFF
--- a/promora-app/App.tsx
+++ b/promora-app/App.tsx
@@ -1,24 +1,50 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { WelcomeScreen } from './screens/Auth/WelcomeScreen';
 import { LoginScreen } from './screens/Auth/LoginScreen';
 import { SignupScreen } from './screens/Auth/SignupScreen';
-import { DashboardScreen } from './screens/Influencer/DashboardScreen';
+import { ForgotPasswordScreen } from './screens/Auth/ForgotPasswordScreen';
+import { OnboardingScreen } from './screens/Auth/OnboardingScreen';
+import { DashboardScreen as InfluencerDashboard } from './screens/Influencer/DashboardScreen';
 import { DiscoverScreen } from './screens/Brand/DiscoverScreen';
+import { BrandDashboardScreen } from './screens/Brand/BrandDashboardScreen';
 import { AdminDashboardScreen } from './screens/Admin/AdminDashboardScreen';
 
 const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator();
+
+function BrandTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Dashboard" component={BrandDashboardScreen} />
+      <Tab.Screen name="Discover" component={DiscoverScreen} />
+    </Tab.Navigator>
+  );
+}
+
+function InfluencerTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Dashboard" component={InfluencerDashboard} />
+    </Tab.Navigator>
+  );
+}
 
 export default function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator>
-        <Tab.Screen name="Login" component={LoginScreen} />
-        <Tab.Screen name="Signup" component={SignupScreen} />
-        <Tab.Screen name="Influencer" component={DashboardScreen} />
-        <Tab.Screen name="Brand" component={DiscoverScreen} />
-        <Tab.Screen name="Admin" component={AdminDashboardScreen} />
-      </Tab.Navigator>
+      <Stack.Navigator initialRouteName="Welcome" screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="Welcome" component={WelcomeScreen} />
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Signup" component={SignupScreen} />
+        <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+        <Stack.Screen name="Brand" component={BrandTabs} />
+        <Stack.Screen name="Influencer" component={InfluencerTabs} />
+        <Stack.Screen name="Admin" component={AdminDashboardScreen} />
+      </Stack.Navigator>
     </NavigationContainer>
   );
 }

--- a/promora-app/screens/Auth/ForgotPasswordScreen.tsx
+++ b/promora-app/screens/Auth/ForgotPasswordScreen.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, TextInput } from 'react-native';
+import { GradientButton } from '../../components/GradientButton';
+import { theme } from '../../theme';
+
+export const ForgotPasswordScreen = () => (
+  <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+    <Text style={{ fontFamily: theme.fontFamily, fontSize: 24, marginBottom: 12 }}>
+      Reset Password
+    </Text>
+    <TextInput placeholder="Email" style={{ borderWidth: 1, marginBottom: 8, padding: 8 }} />
+    <GradientButton text="Send Reset Link" onPress={() => {}} />
+  </View>
+);

--- a/promora-app/screens/Auth/OnboardingScreen.tsx
+++ b/promora-app/screens/Auth/OnboardingScreen.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import { View, Text } from 'react-native';
+import { GradientButton } from '../../components/GradientButton';
+import { theme } from '../../theme';
+
+export const OnboardingScreen = () => {
+  const [step, setStep] = useState(1);
+  const next = () => setStep(step + 1);
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <Text style={{ fontFamily: theme.fontFamily, fontSize: 24, marginBottom: 12 }}>
+        {`Onboarding Step ${step}`}
+      </Text>
+      <GradientButton text={step >= 3 ? 'Finish' : 'Next'} onPress={next} />
+    </View>
+  );
+};

--- a/promora-app/screens/Auth/WelcomeScreen.tsx
+++ b/promora-app/screens/Auth/WelcomeScreen.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { GradientButton } from '../../components/GradientButton';
+import { theme } from '../../theme';
+import { useNavigation } from '@react-navigation/native';
+
+export const WelcomeScreen = () => {
+  const navigation = useNavigation<any>();
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <Text style={{ fontFamily: theme.fontFamily, fontSize: 24, marginBottom: 20 }}>
+        Welcome to Promora
+      </Text>
+      <GradientButton text="I'm a Brand" onPress={() => navigation.navigate('Login', { role: 'Brand' })} />
+      <View style={{ height: 12 }} />
+      <GradientButton text="I'm an Influencer" onPress={() => navigation.navigate('Login', { role: 'Influencer' })} />
+      <View style={{ height: 12 }} />
+      <GradientButton text="Admin" onPress={() => navigation.navigate('Login', { role: 'Admin' })} />
+    </View>
+  );
+};

--- a/promora-app/screens/Brand/BrandDashboardScreen.tsx
+++ b/promora-app/screens/Brand/BrandDashboardScreen.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { ScrollView, Text } from 'react-native';
+import { CampaignCard } from '../../components/CampaignCard';
+import { CreatorCard } from '../../components/CreatorCard';
+import { theme } from '../../theme';
+
+export const BrandDashboardScreen = () => (
+  <ScrollView contentContainerStyle={{ padding: 20 }}>
+    <Text style={{ fontFamily: theme.fontFamily, fontSize: 24, marginBottom: 12 }}>
+      Brand Dashboard
+    </Text>
+    <CampaignCard status="Active" budget="$2000" reach="20k" />
+    <CreatorCard name="Top Influencer" rating={4.9} followers={50000} />
+  </ScrollView>
+);

--- a/promora-app/screens/Brand/BrandSettingsScreen.tsx
+++ b/promora-app/screens/Brand/BrandSettingsScreen.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { theme } from '../../theme';
+
+export const BrandSettingsScreen = () => (
+  <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+    <Text style={{ fontFamily: theme.fontFamily, fontSize: 24 }}>Brand Settings</Text>
+  </View>
+);


### PR DESCRIPTION
## Summary
- add Welcome, Onboarding and ForgotPassword auth screens
- add Brand dashboard and settings placeholders
- wire navigation with stack + tabs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851b79e20d0833189a4cb2c2af16f23